### PR TITLE
Fix LSP completion when applying a `TextEdit` with `newText`

### DIFF
--- a/lua/source/lsp.lua
+++ b/lua/source/lsp.lua
@@ -10,10 +10,10 @@ M.getCompletionItems = function(_, _)
   return M.items
 end
 
-local function get_completion_word(item)
+local function get_completion_word(item, prefix)
   if item.textEdit ~= nil and item.textEdit ~= vim.NIL
     and item.textEdit.newText ~= nil and (item.insertTextFormat ~= 2 or vim.fn.exists('g:loaded_vsnip_integ')) then
-    return item.textEdit.newText
+    return prefix .. item.textEdit.newText
   elseif item.insertText ~= nil and item.insertText ~= vim.NIL then
     return item.insertText
   end
@@ -49,7 +49,7 @@ local function text_document_completion_list_to_complete_items(result, prefix)
       end
       item.info = info
 
-      item.word = get_completion_word(completion_item)
+      item.word = get_completion_word(completion_item, prefix)
       item.user_data = {
         lsp = {
           completion_item = completion_item

--- a/lua/source/lsp.lua
+++ b/lua/source/lsp.lua
@@ -13,7 +13,13 @@ end
 local function get_completion_word(item, prefix)
   if item.textEdit ~= nil and item.textEdit ~= vim.NIL
     and item.textEdit.newText ~= nil and (item.insertTextFormat ~= 2 or vim.fn.exists('g:loaded_vsnip_integ')) then
-    return prefix .. item.textEdit.newText
+    local start_range = item.textEdit.range["start"]
+    local end_range = item.textEdit.range["end"]
+    if start_range.line == end_range.line and start_range.character == end_range.character then
+        return prefix .. item.textEdit.newText
+    else
+        return item.textEdit.newText
+    end
   elseif item.insertText ~= nil and item.insertText ~= vim.NIL then
     return item.insertText
   end


### PR DESCRIPTION
The language server specification says that `newText` is the text to be inserted.

````
A textual edit applicable to a text document.

```typescript
interface TextEdit {
	/**
	 * The range of the text document to be manipulated. To insert
	 * text into a document create a range where start === end.
	 */
	range: Range;
	/**
	 * The string to be inserted. For delete operations use an
	 * empty string.
	 */
	newText: string;
}
```
````

See https://github.com/microsoft/language-server-protocol/blob/ba5483e93d888e22ab38dce258b2471e30005726/_specifications/specification-3-16.md#L515 for reference.

In the current implementation of completion-nvim, `item.word` is set to `item.textEdit.newText`. See the following lines:

https://github.com/nvim-lua/completion-nvim/blob/d28179c685b701d2475aa6125c82717b79a74e82/lua/source/lsp.lua#L14-L16

According to the specification, if I'm trying to complete `pri` and a language server may return a `TextEdit` with `newText` for it like `ntln`, and then `item.word` is set to `ntln` instead of `println`.

This makes it such that when the matching happens between `prefix` and `item.word`, `is_match` is always set to `false`. See the following lines for reference:

https://github.com/nvim-lua/completion-nvim/blob/d28179c685b701d2475aa6125c82717b79a74e82/lua/completion/matching.lua#L53

This PR will fix this specific issue.
