### PR TITLE
[WIP]rework: introducing cache mechanism for completion items

### DIFF
--- a/lua/completion/complete.lua
+++ b/lua/completion/complete.lua
@@ -2,8 +2,11 @@ local vim = vim
 local api = vim.api
 local util = require 'completion.util'
 local ins = require 'completion.source.ins_complete'
+local match = require'completion.matching'
 
 local M = {}
+
+local cache_complete_items = {}
 
 local function checkCallback(callback_array)
   for _,val in ipairs(callback_array) do
@@ -18,9 +21,13 @@ end
 local function getCompletionItems(items_array, prefix)
   local complete_items = {}
   for _,func in ipairs(items_array) do
-    vim.list_extend(complete_items, func(prefix, util.fuzzy_score))
+    vim.list_extend(complete_items, func(prefix))
   end
   return complete_items
+end
+
+M.clearCache = function()
+  cache_complete_items = {}
 end
 
 -- perform completion
@@ -31,48 +38,67 @@ M.performComplete = function(complete_source, complete_items_map, manager, bufnr
     -- ins-complete source
     ins.triggerCompletion(manager, complete_source.mode)
   elseif vim.fn.has_key(complete_source, "complete_items") > 0 then
-    -- use callback_array to handle async behavior
-    local callback_array = {}
-    local items_array = {}
-    -- collect getCompleteItems function of current completion source
-    for _, item in ipairs(complete_source.complete_items) do
-      local complete_items = complete_items_map[item]
-      if complete_items ~= nil then
-        if complete_items.callback == nil then
-          table.insert(callback_array, true)
-        else
-          table.insert(callback_array, complete_items.callback)
-          complete_items.trigger(prefix, textMatch, bufnr, manager)
+    if #cache_complete_items == 0 then
+      -- use callback_array to handle async behavior
+      local callback_array = {}
+      local items_array = {}
+      -- collect getCompleteItems function of current completion source
+      for _, item in ipairs(complete_source.complete_items) do
+        local complete_items = complete_items_map[item]
+        if complete_items ~= nil then
+          if complete_items.callback == nil then
+            table.insert(callback_array, true)
+          else
+            table.insert(callback_array, complete_items.callback)
+            complete_items.trigger(prefix, textMatch, bufnr, manager)
+          end
+          table.insert(items_array, complete_items.item)
         end
-        table.insert(items_array, complete_items.item)
+      end
+
+      local timer = vim.loop.new_timer()
+      timer:start(20, 50, vim.schedule_wrap(function()
+        if manager.insertChar == true and not timer:is_closing() then
+          timer:stop()
+          timer:close()
+        end
+        -- only perform complete when callback_array are all true
+        if checkCallback(callback_array) == true and timer:is_closing() == false then
+          if api.nvim_get_mode()['mode'] == 'i' or api.nvim_get_mode()['mode'] == 'ic' then
+            local items = getCompletionItems(items_array, prefix)
+            if vim.g.completion_sorting ~= "none" then
+              util.sort_completion_items(items)
+            end
+            if #items ~= 0 then
+              -- reset insertChar and handle auto changing source
+              cache_complete_items = items
+              vim.fn.complete(textMatch+1, items)
+              manager.changeSource = false
+            else
+              manager.changeSource = true
+            end
+          end
+          timer:stop()
+          timer:close()
+        end
+      end))
+    else
+      if api.nvim_get_mode()['mode'] == 'i' or api.nvim_get_mode()['mode'] == 'ic' then
+        local items = {}
+        for _, item in ipairs(cache_complete_items) do
+          match.matching(items, prefix, item)
+        end
+        if #items ~= 0 then
+          -- reset insertChar and handle auto changing source
+          cache_complete_items = items
+          vim.fn.complete(textMatch+1, items)
+          manager.changeSource = false
+        else
+          cache_complete_items = {}
+          manager.changeSource = true
+        end
       end
     end
-
-    local timer = vim.loop.new_timer()
-    timer:start(20, 50, vim.schedule_wrap(function()
-      if manager.insertChar == true and not timer:is_closing() then
-        timer:stop()
-        timer:close()
-      end
-      -- only perform complete when callback_array are all true
-      if checkCallback(callback_array) == true and timer:is_closing() == false then
-        if api.nvim_get_mode()['mode'] == 'i' or api.nvim_get_mode()['mode'] == 'ic' then
-          local items = getCompletionItems(items_array, prefix)
-          if vim.g.completion_sorting ~= "none" then
-            util.sort_completion_items(items)
-          end
-          if #items ~= 0 then
-            -- reset insertChar and handle auto changing source
-            vim.fn.complete(textMatch+1, items)
-            manager.changeSource = false
-          else
-            manager.changeSource = true
-          end
-        end
-        timer:stop()
-        timer:close()
-      end
-    end))
   end
 end
 

--- a/lua/completion/source.lua
+++ b/lua/completion/source.lua
@@ -107,6 +107,7 @@ local triggerCurrentCompletion = function(manager, bufnr, line_to_cursor, prefix
     return
   end
   if triggered then
+    complete.clearCache()
     M.chain_complete_index = 1
   end
 
@@ -127,6 +128,7 @@ end
 
 -- Activate when manually triggered completion or manually changing completion source
 function M.triggerCompletion(force, manager)
+  complete.clearCache()
   if force then
     M.chain_complete_index = 1
   end
@@ -148,6 +150,8 @@ function M.autoCompletion(manager)
   -- reset completion when deleting character in insert mode
   if #prefix < M.prefixLength and vim.fn.pumvisible() == 0 then
     M.chain_complete_index = 1
+    -- not sure if I should clear cache here
+    complete.clearCache()
     -- api.nvim_input("<c-g><c-g>")
     if vim.g.completion_trigger_on_delete == 1 then
       M.triggerCompletion(false, manager)
@@ -156,8 +160,9 @@ function M.autoCompletion(manager)
   end
   M.prefixLength = #prefix
 
-  -- force reset chain completion if entering a new word
+  -- force reset chain completion and clear completion cache if entering a new word
   if (#prefix < length) then
+    complete.clearCache()
     M.chain_complete_index = 1
     M.stop_complete = false
     manager.changeSource = false

--- a/lua/completion/source/lsp.lua
+++ b/lua/completion/source/lsp.lua
@@ -53,8 +53,6 @@ local function text_document_completion_list_to_complete_items(result, prefix)
           info = documentation
         elseif type(documentation) == 'table' and type(documentation.value) == 'string' then
           info = documentation.value
-        -- else
-          -- TODO(ashkan) Validation handling here?
         end
       end
       item.info = info
@@ -95,7 +93,7 @@ M.triggerFunction = function(prefix, _, bufnr, _)
       M.callback = true
       return
     end
-    local matches = text_document_completion_list_to_complete_items(result, prefix, util.fuzzy_score)
+    local matches = text_document_completion_list_to_complete_items(result, prefix)
     M.items = matches
     M.callback = true
   end)


### PR DESCRIPTION
Currently in order to do fuzzy matching and stuff, we send completion request to server on every keystrokes, which is... kind of dump. The rework target is to send request only on every new word or deletion, and then cache the complete_items. We can just sending one request per words and theoretically this also allow true fuzzy finding which is server independent (since we only get words on first keystroke).