### PR TITLE
Prefer vsnip's additionalTextEdits expansion

### DIFF
--- a/lua/completion.lua
+++ b/lua/completion.lua
@@ -55,17 +55,23 @@ function M.confirmCompletion()
     local lnum, _ = unpack(api.nvim_win_get_cursor(0))
     if complete_item.user_data.lsp ~= nil then
       local item = complete_item.user_data.lsp.completion_item
-      local bufnr = api.nvim_get_current_buf()
-      if item.additionalTextEdits then
-        local edits = vim.tbl_filter(
-          function(x) return x.range.start.line ~= (lnum - 1) end,
-          item.additionalTextEdits
-        )
-        vim.lsp.util.apply_text_edits(edits, bufnr)
-      end
       if vim.fn.exists('g:loaded_vsnip_integ') == 1 then
-        api.nvim_call_function('vsnip_integ#on_complete_done_for_lsp',
-          { { completed_item = complete_item, completion_item = item } })
+        api.nvim_call_function('vsnip_integ#do_complete_done', {
+          {
+            completed_item = complete_item,
+            completion_item = item,
+            apply_additional_text_edits = true
+          }
+        })
+      else
+        if item.additionalTextEdits then
+          local bufnr = api.nvim_get_current_buf()
+          local edits = vim.tbl_filter(
+            function(x) return x.range.start.line ~= (lnum - 1) end,
+            item.additionalTextEdits
+          )
+          vim.lsp.util.apply_text_edits(edits, bufnr)
+        end
       end
     end
 


### PR DESCRIPTION
This PR aims to use the `vsnip_integ#do_complete_done` that replaces `vsnip_integ#on_complete_done_for_lsp`.

And one more thing, if vsnip_integ available, prefer vsnip_integ's additionalTextEdits behavior.
Because additionalTextEdits is a bit difficult to implement correctly.

When completion-nvim has a correct additionalTextEdits implementation, you can disable `vsnip_integ`'s behavior by `apply_additional_text_edits = false`.

The additionalTextEdits should follow the cursor position after applying textEdits.

I was tested the case of https://gitter.im/completion-nvim/community?at=5efda68c6c06cd1bf469b48c

