### PR TITLE
[WIP]feat: support lua per server setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,11 @@ let g:completion_trigger_on_delete = 1
 let g:completion_timer_cycle = 200 "default value is 80
 ```
 
+### Per Server Setup
+
+- You can have different setup for each server in completion-nvim using lua, see [wiki]
+(https://github.com/nvim-lua/completion-nvim/wiki/per-server-setup-by-lua) for more guide.
+
 ## Compatibility with diagnostic-nvim
 
 - This plugin only focuses on the **completion** part of the built-in LSP. If

--- a/lua/completion/chain_completion.lua
+++ b/lua/completion/chain_completion.lua
@@ -1,6 +1,7 @@
 local vim = vim
 local api = vim.api
 local util = require 'completion.util'
+local opt = require 'completion.option'
 local M ={}
 
 --------------------------------------------------------------
@@ -68,7 +69,7 @@ end
 -- preserve compatiblity of completion_chain_complete_list
 function M.getChainCompleteList(filetype)
 
-  local chain_complete_list = chain_list_to_tree(vim.g.completion_chain_complete_list)
+  local chain_complete_list = chain_list_to_tree(opt.get_option('chain_complete_list'))
   -- check if chain_complete_list is a array
 
   if chain_complete_list[filetype] then

--- a/lua/completion/health.lua
+++ b/lua/completion/health.lua
@@ -1,6 +1,7 @@
 local vim = vim
 local api = vim.api
 local source = require 'completion.source'
+local opt = require 'completion.option'
 
 local health_start = vim.fn["health#report_start"]
 local health_ok = vim.fn['health#report_ok']
@@ -14,7 +15,7 @@ local checkCompletionSource = function()
 end
 
 local checkSnippetSource = function()
-  local snippet_source = vim.g.completion_enable_snippet
+  local snippet_source = opt.get_option('enable_snippet')
   if snippet_source == nil then
     health_info("You haven't setup any snippet source.")
   elseif snippet_source == 'UltiSnips' then

--- a/lua/completion/hover.lua
+++ b/lua/completion/hover.lua
@@ -2,6 +2,7 @@
 local vim = vim
 local validate = vim.validate
 local api = vim.api
+local opt = require 'completion.option'
 
 local M = {}
 
@@ -190,11 +191,11 @@ local fancy_floating_markdown = function(contents, opts)
   local height = #stripped
   local bufnr = api.nvim_create_buf(false, true)
   local winnr
-  if vim.g.completion_docked_hover == 1 then
-    if height > vim.g.completion_docked_maximum_size then
-      height = vim.g.completion_docked_maximum_size
-    elseif height < vim.g.completion_docked_minimum_size then
-      height = vim.g.completion_docked_minimum_size
+  if opt.get_option('docked_hover') == 1 then
+    if height > opt.get_option('docked_maximum_size') then
+      height = opt.get_option('docked_maximum_size')
+    elseif height < opt.get_option('docked_minimum_size') then
+      height = opt.get_option('docked_minimum_size')
     end
     local row
     if vim.fn.winline() > api.nvim_get_option('lines')/2 then

--- a/lua/completion/matching.lua
+++ b/lua/completion/matching.lua
@@ -1,9 +1,10 @@
 local vim = vim
-local util = require'completion.util'
+local util = require 'completion.util'
+local opt = require 'completion.option'
 local M = {}
 
 local function fuzzy_match(prefix, word)
-  if vim.g.completion_matching_ignore_case == 1 then
+  if opt.get_option('matching_ignore_case') == 1 then
     prefix = string.lower(prefix)
     word = string.lower(word)
   end
@@ -17,7 +18,7 @@ end
 
 
 local function substring_match(prefix, word)
-  if vim.g.completion_matching_ignore_case == 1 then
+  if opt.get_option('matching_ignore_case') == 1 then
     prefix = string.lower(prefix)
     word = string.lower(word)
   end
@@ -29,7 +30,7 @@ local function substring_match(prefix, word)
 end
 
 local function exact_match(prefix, word)
-  if vim.g.completion_matching_ignore_case == 1 then
+  if opt.get_option('matching_ignore_case') == 1 then
     prefix = string.lower(prefix)
     word = string.lower(word)
   end
@@ -47,7 +48,7 @@ local matching_strategy = {
 }
 
 M.matching = function(complete_items, prefix, item)
-  local matcher_list = vim.b.completion_matching_strategy_list or vim.g.completion_matching_strategy_list
+  local matcher_list = opt.get_option('matching_strategy_list')
   local matching_priority = 2
   for _, method in ipairs(matcher_list) do
     local is_match, score = matching_strategy[method](prefix, item.word)

--- a/lua/completion/option.lua
+++ b/lua/completion/option.lua
@@ -1,0 +1,26 @@
+local M = {}
+
+
+-- fallback to using global variable as default
+local completion_opt_metatable = {
+  __index = function(_, key)
+    key = 'completion_'..key
+    return vim.g[key]
+  end
+}
+
+local option_table = setmetatable({}, completion_opt_metatable)
+
+M.set_option_table = function(opt)
+  if opt ~= nil then
+    option_table = setmetatable(opt, completion_opt_metatable)
+  else
+    option_table = setmetatable({}, completion_opt_metatable)
+  end
+end
+
+M.get_option = function(opt)
+  return option_table[opt]
+end
+
+return M

--- a/lua/completion/source.lua
+++ b/lua/completion/source.lua
@@ -6,6 +6,7 @@ local chain_completion = require 'completion.chain_completion'
 local lsp = require 'completion.source.lsp'
 local snippet = require 'completion.source.snippet'
 local path = require 'completion.source.path'
+local opt = require 'completion.option'
 
 local M = {}
 
@@ -74,7 +75,7 @@ local triggerCurrentCompletion = function(manager, bufnr, line_to_cursor, prefix
   local source_trigger_character = getTriggerCharacter(complete_source)
   local triggered
   triggered = util.checkTriggerCharacter(line_to_cursor, source_trigger_character) or
-              util.checkTriggerCharacter(line_to_cursor, vim.g.completion_trigger_character)
+              util.checkTriggerCharacter(line_to_cursor, opt.get_option('trigger_character'))
 
   if complete_source.complete_items ~= nil then
     for _, source in ipairs(complete_source.complete_items) do
@@ -102,7 +103,7 @@ local triggerCurrentCompletion = function(manager, bufnr, line_to_cursor, prefix
     end
   end
 
-  local length = vim.g.completion_trigger_keyword_length
+  local length = opt.get_option('trigger_keyword_length')
   if #prefix < length and not triggered and not force then
     return
   end
@@ -150,7 +151,7 @@ function M.autoCompletion(manager)
   local prefix = line_to_cursor:sub(textMatch+1)
   local rev_textMatch = #cursor_to_end - vim.fn.match(cursor_to_end:reverse(), '\\k*$')
   local suffix = cursor_to_end:sub(1, rev_textMatch)
-  local length = vim.g.completion_trigger_keyword_length
+  local length = opt.get_option('trigger_keyword_length')
 
   -- reset completion when deleting character in insert mode
   if #prefix < M.prefixLength and vim.fn.pumvisible() == 0 then
@@ -158,7 +159,7 @@ function M.autoCompletion(manager)
     -- not sure if I should clear cache here
     complete.clearCache()
     -- api.nvim_input("<c-g><c-g>")
-    if vim.g.completion_trigger_on_delete == 1 then
+    if opt.get_option('trigger_on_delete') == 1 then
       M.triggerCompletion(false, manager)
     end
     M.stop_complete = false

--- a/lua/completion/util.lua
+++ b/lua/completion/util.lua
@@ -4,6 +4,7 @@
 
 local vim = vim
 local api = vim.api
+local opt = require 'completion.option'
 local M = {}
 
 function M.is_list(thing)


### PR DESCRIPTION
Support using lua setup in the `on_attach` function. This allow full lua setup for `completion-nvim` and simply a better server based setup for every variable.

Simply the proposed method is user can pass in a table in `on_attach` functions. By using metatables on our side, we can point back to the origin global variable if it's not in the configure table. This will not introduce any backward compatible issue and will allow us only changing the metatable if you introduce some variable changes on our side. And since it's setup in `on_attach` all the variable here are always per-server base.

Setting it up is actually very straight forward, just use the same variable name as the global variable without the `completion_` part (cause we don't need to prevent namespace collision here). An example is:
```lua
  require'completion'.on_attach({
      sorting = 'alphabet',
      matching_strategy_list = {'exact', 'fuzzy'},
      enable_auto_hover  = 0,
      enable_auto_signature = 0,
    })
```

TODO
- [x] allow full lua per-server based setup/
- [x] handle `chain_completion_list` correctly, because we're now setting a per-server setup so we don't need a super long `chain_completion_list`, instead we can handle it as a special case in the metatable.
- [ ] some error handling to prevent mistype?

cc @vigoux @clason Just thinks you guys might be interested in this:)