### PR TITLE
source/lsp: fix check for clients presence

### DIFF
--- a/lua/completion/source/lsp.lua
+++ b/lua/completion/source/lsp.lua
@@ -120,11 +120,21 @@ M.getCallback = function()
   return M.callback
 end
 
+local buf_has_clients = function()
+  -- buf_get_clients() may return an associative table that has numbers as
+  -- keys. So while using # may work at first, it stops working if the client
+  -- is restarted.
+  for _ in pairs(vim.lsp.buf_get_clients()) do
+    return true
+  end
+  return false
+end
+
 M.triggerFunction = function(_, params)
   local position_param = vim.lsp.util.make_position_params()
   M.callback = false
   M.items = {}
-  if #vim.lsp.buf_get_clients() == 0 then
+  if not buf_has_clients() then
     M.callback = true
     return
   end


### PR DESCRIPTION
While vim.lsp.buf_get_clients() returns an array that uses numbers as
indices, those numbers are not guaranteed to start at 1, so using #
isn't really correct.

Closes #159.