### PR TITLE
Consider completion item "dup" property if provided. Fixes #152.

### DIFF
--- a/lua/completion/util.lua
+++ b/lua/completion/util.lua
@@ -41,7 +41,7 @@ function M.addCompletionItems(item_table, item)
       info = item.info or '',
       priority = item.priority or 1,
       icase = 1,
-      dup = 1,
+      dup = item.dup or 1,
       empty = 1,
       user_data = item.user_data or {},
     })


### PR DESCRIPTION
This is the fix for https://github.com/nvim-lua/completion-nvim/issues/152.
Basically, if someone provides `dup` option explicitly, it is considered. If not, defaults to 1.

I think this should fix the issue for custom sources where we can provide this property, but it should also maintain backward compatibility.