### PR TITLE
fix: health check for neosnippet source

### DIFF
--- a/lua/completion/health.lua
+++ b/lua/completion/health.lua
@@ -25,7 +25,7 @@ local checkSnippetSource = function()
       health_error("UltiSnips is not available! Check if you install Ultisnips correctly.")
     end
   elseif snippet_source == 'Neosnippet' then
-    if string.match(api.nvim_get_option("rtp"), ".*neosnippet.vim.*") == 1 then
+    if string.match(api.nvim_get_option("rtp"), ".*neosnippet.vim.*") then
       health_ok("You are using Neosnippet as your snippet source")
     else
       health_error("Neosnippet is not available! Check if you install Neosnippet correctly.")


### PR DESCRIPTION
`:checkhealth` kept failing for me when using `Neosnippet.vim` as my snippet source. Looking at the code it turns out that the check expects a different result from `string.match` than what is actually returned. This PR updates the check to match the other health checks for snippets 🙂 Making the health check work properly also stopped the completion from printing several error messages related to snippets.