### PR TITLE
Fix error when there are no global snippets defined in snippets.nvim

### DIFF
--- a/lua/completion/source/snippet.lua
+++ b/lua/completion/source/snippet.lua
@@ -81,7 +81,7 @@ M.getSnippetsNvimItems = function(prefix)
   local snippets = require 'snippets'
   if not snippets then return {} end
   local ft = vim.bo.filetype
-  local snippetsList = vim.tbl_extend('force', snippets.snippets._global, snippets.snippets[ft] or {})
+  local snippetsList = vim.tbl_extend('force', snippets.snippets._global or {}, snippets.snippets[ft] or {})
   local complete_items = {}
   if vim.tbl_isempty(snippetsList) == 0 then
     return {}


### PR DESCRIPTION
I just testing out `snippets.nvim` today and tried to integrate it with `completion-nvim`, but I ran into this issue because I haven't defined any global snippets for `snippets.nvim` yet.

This PR fixes the issue.