### PR TITLE
Made completion_syntax_at_point option do work

### DIFF
--- a/lua/completion/chain_completion.lua
+++ b/lua/completion/chain_completion.lua
@@ -40,20 +40,19 @@ end
 
 local function getScopedChain(ft_subtree)
 
-  local function syntaxGroupAtPoint()
+  local syntax_getter = function()
     local pos = api.nvim_win_get_cursor(0)
     return vim.fn.synIDattr(vim.fn.synID(pos[1], pos[2]-1, 1), "name")
   end
 
-  local VAR_NAME = "completion_syntax_at_point"
-
-  local syntax_getter
-
   -- If this option is effectively a function, use it to determine syntax group at point
-  if vim.fn.exists("g:" .. VAR_NAME) > 0 and vim.is_callable(api.nvim_get_var(VAR_NAME)) > 0 then
-    syntax_getter = api.nvim_get_var(VAR_NAME)
-  else
-    syntax_getter = syntaxGroupAtPoint
+  local syntax_at_point = opt.get_option("syntax_at_point")
+  if syntax_at_point then
+      if vim.is_callable(syntax_at_point) then
+          syntax_getter = syntax_at_point
+      elseif type(syntax_at_point) == "string" and vim.fn.exists("*" .. syntax_at_point) then
+          syntax_getter = vim.fn[syntax_at_point]
+      end
   end
 
   local atPoint = syntax_getter():lower()


### PR DESCRIPTION
The option `g:completion_syntax_at_point` was imported by PR #20, but it has never worked.

This PR made it can be either a vim function name or a lua function.

Examples:

* vim function name
```vim
function! lsp#completion#syntax_at_point() abort
    return synIDattr(synID(line('.'), col('.'), 1), 'name')
endfunction

let g:completion_syntax_at_point = 'lsp#completion#syntax_at_point'
```

* lua function
```lua
local on_attach = function(client)
    require('completion').on_attach {
        syntax_at_point = function()
            local pos = vim.api.nvim_win_get_cursor(0)
            return vim.fn.synIDattr(vim.fn.synID(pos[1], pos[2]-1, 1), "name")
        end,
    }
end

require('nvim_lsp').<your_pls>.setup {
    on_attach = on_attach
}
```

This option is useful when cooperating with `treesitter`, because we cannot get the syntax group by using `synIDattr` function that way. The following is an example:
```lua
local function syntax_at_point()
    if vim.g.loaded_nvim_treesitter and vim.g.loaded_nvim_treesitter > 0 then
        local current_node = require('nvim-treesitter/ts_utils').get_node_at_cursor()
        if current_node then
            return current_node:type()
        end
    end
    -- fallback
    local pos = api.nvim_win_get_cursor(0)
    return vim.fn.synIDattr(vim.fn.synID(pos[1], pos[2], 1), "name")
end
```