### PR TITLE
fix: typo in health.lua causing check fail for vim-vsnip

### DIFF
--- a/lua/completion/health.lua
+++ b/lua/completion/health.lua
@@ -24,7 +24,7 @@ local checkSnippetSource = function()
     local snippet_sources = {
         ["UltiSnips"] = "ultisnips",
         ["Neosnippet"] = "neosnippet.vim",
-        ["vim-snip"] = "vsnip",
+        ["vim-vsnip"] = "vsnip",
         ["snippets.nvim"] = "snippets.nvim"
     }
 


### PR DESCRIPTION
My previous [PR](https://github.com/nvim-lua/completion-nvim/pull/176) contained a typo which caused the health check to fail for vim-vsnip. Sorry for that!