### PR TITLE
[WIP] Make <CR> "extensible" for other plugins.

### DIFF
--- a/lua/completion.lua
+++ b/lua/completion.lua
@@ -224,10 +224,14 @@ M.on_attach = function(option)
     api.nvim_command("autocmd CompleteDone <buffer> lua require'completion'.on_CompleteDone()")
   api.nvim_command("augroup end")
   if string.len(opt.get_option('confirm_key')) ~= 0 then
-    api.nvim_buf_set_keymap(0, 'i', opt.get_option('confirm_key'),
+    api.nvim_set_keymap('i', '<Plug>(completion_confirm_expr)',
       'pumvisible() ? complete_info()["selected"] != "-1" ? "\\<Plug>(completion_confirm_completion)" :'..
-      ' "\\<c-e>\\<CR>" : "\\<CR>"',
-      {silent=false, noremap=false, expr=true})
+      ' "\\<C-e>" : empty(maparg("\\'..opt.get_option('confirm_key')..'", "i")) ? "\\<CR>" : ""',
+      {silent=false, noremap=true, expr=true})
+
+    api.nvim_buf_set_keymap(0, 'i', opt.get_option('confirm_key'),
+      vim.fn.maparg(opt.get_option('confirm_key'), 'i')..'<Plug>(completion_confirm_expr)',
+      {silent=false, noremap=false})
   end
   -- overwrite vsnip_integ autocmd since we handle it on ourself in confirmCompletion
   if vim.fn.exists("#vsnip_integ") then


### PR DESCRIPTION
Great plugin! I realized that this plugin clobbers any prior mapping to `<CR>` in insert-mode. Specifically, I noticed that [vim-endwise][0] doesn't work because it maps `<CR>`, which this plugin clobbers in any buffer where it is activated.

When I used COC, I ran into the same problem. [This comment][1] is my solution to that problem: map a plugin mapping to the added functionality and chain that to the desired mapping.

[0]:https://github.com/tpope/vim-endwise
[1]:https://github.com/tpope/vim-endwise/issues/22#issuecomment-554654745