### PR TITLE
Fixes expand when using custom label for snippets

### DIFF
--- a/lua/completion.lua
+++ b/lua/completion.lua
@@ -132,14 +132,14 @@ local function hasConfirmedCompletion()
   if opt.get_option('enable_auto_paren') == 1 then
     autoAddParens(completed_item)
   end
-  if completed_item.kind == 'UltiSnips' then
+  if completed_item.user_data.snippet_source == 'UltiSnips' then
     api.nvim_call_function('UltiSnips#ExpandSnippet', {})
-  elseif completed_item.kind == 'Neosnippet' then
+  elseif completed_item.user_data.snippet_source == 'Neosnippet' then
     api.nvim_input("<c-r>".."=neosnippet#expand('"..completed_item.word.."')".."<CR>")
-  elseif completed_item.kind == 'vim-vsnip' then
+  elseif completed_item.user_data.snippet_source == 'vim-vsnip' then
     api.nvim_call_function('vsnip#expand', {})
-  elseif completed_item.kind == 'snippets.nvim' then
-	require'snippets'.expand_at_cursor()
+  elseif completed_item.user_data.snippet_source == 'snippets.nvim' then
+    require'snippets'.expand_at_cursor()
   end
 end
 
@@ -266,4 +266,3 @@ M.on_attach = function(option)
 end
 
 return M
-

--- a/lua/completion/source/snippet.lua
+++ b/lua/completion/source/snippet.lua
@@ -24,7 +24,7 @@ M.getUltisnipItems = function(prefix)
     item.word = key
     item.kind = kind
     item.priority = priority
-    local user_data = {hover = val}
+    local user_data = {snippet_source = 'UltiSnips', hover = val}
     item.user_data = user_data
     match.matching(complete_items, prefix, item)
   end
@@ -45,7 +45,7 @@ M.getNeosnippetItems = function(prefix)
     if key == true then
       key = 'true'
     end
-    local user_data = {hover = val.description}
+    local user_data = {snippet_source = 'Neosnippet', hover = val.description}
     local item = {}
     item.word = key
     item.kind = kind
@@ -69,7 +69,7 @@ M.getVsnipItems = function(prefix)
   for _, source in pairs(snippetsList) do
     for _, snippet in pairs(source) do
       for _, word in pairs(snippet.prefix) do
-        local user_data = {hover = snippet.description}
+        local user_data = {snippet_source = 'vim-vsnip', hover = snippet.description}
         local item = {}
         item.word = word
         item.kind = kind
@@ -95,19 +95,20 @@ M.getSnippetsNvimItems = function(prefix)
   end
   local priority = vim.g.completion_items_priority['snippets.nvim'] or 1
   local kind = 'snippets.nvim'
+  kind = opt.get_option('customize_lsp_label')[kind] or kind
   for short, long in pairs(snippetsList) do
-	-- TODO: We cannot put the parsed snippet itself in userdata, since it may
-	-- contain Lua functions (see
-	-- https://github.com/norcalli/snippets.nvim#notes-because-this-is-beta-release-software)
-	local user_data = {}
-	local item = {}
-	item.word = short
-	item.kind = kind
-	-- TODO: Turn actual snippet text into label/description?
-	item.menu = short
-	item.priority = priority
-	item.user_data = user_data
-	match.matching(complete_items, prefix, item)
+    -- TODO: We cannot put the parsed snippet itself in userdata, since it may
+    -- contain Lua functions (see
+    -- https://github.com/norcalli/snippets.nvim#notes-because-this-is-beta-release-software)
+    local user_data = {snippet_source = 'snippets.nvim'}
+    local item = {}
+    item.word = short
+    item.kind = kind
+    -- TODO: Turn actual snippet text into label/description?
+    item.menu = short
+    item.priority = priority
+    item.user_data = user_data
+    match.matching(complete_items, prefix, item)
   end
   return complete_items
 end


### PR DESCRIPTION
Actually i only wanted to add the missing custom label for `snippets.nvim`. This would be an extension of this commit 397cde9642de820ee7e37f818775991ec2df693f. Label can be set with
```lua
local customize_lsp_label = {
  ["snippets.nvim"] = ' [nsnip]'
}

local on_attach = function(_, _)
  require'completion'.on_attach({
    customize_lsp_label = customize_lsp_label,
  })
end
```
Then i realized that using a custom label stops expanding my snippets when triggering completion. 
Would be nice if someone could confirm that this is also happening with one of the other snippet engines(`UltiSnips`, `Neosnippet` and `vim-vsnip`). As far as i see it should happen.
One solution is presented in this pr. I'm not sure if i using `user_data` wrong here. 
Another solution would be this.
```diff
diff --git a/lua/completion.lua b/lua/completion.lua
index 67d2874..35bd270 100644
--- a/lua/completion.lua
+++ b/lua/completion.lua
@@ -132,14 +132,19 @@ local function hasConfirmedCompletion()
   if opt.get_option('enable_auto_paren') == 1 then
     autoAddParens(completed_item)
   end
-  if completed_item.kind == 'UltiSnips' then
+  local custom_label = opt.get_option('customize_lsp_label')
+  if completed_item.kind == 'UltiSnips' or
+      completed_item.kind == custom_label['UltiSnips'] then
     api.nvim_call_function('UltiSnips#ExpandSnippet', {})
-  elseif completed_item.kind == 'Neosnippet' then
+  elseif completed_item.kind == 'Neosnippet' or
+      completed_item.kind == custom_label['Neosnippet'] then
     api.nvim_input("<c-r>".."=neosnippet#expand('"..completed_item.word.."')".."<CR>")
-  elseif completed_item.kind == 'vim-vsnip' then
+  elseif completed_item.kind == 'vim-vsnip' or
+      completed_item.kind == custom_label['vim-vsnip'] then
     api.nvim_call_function('vsnip#expand', {})
-  elseif completed_item.kind == 'snippets.nvim' then
-	require'snippets'.expand_at_cursor()
+  elseif completed_item.kind == 'snippets.nvim' or
+      completed_item.kind == custom_label['snippets.nvim'] then
+    require'snippets'.expand_at_cursor()
   end
 end
```

Would be great to get some input which one you prefer. @haorenW1025 

btw thanks for the great plugin. I really enjoy it.