### PR TITLE
Fix typo in completion_smart_tab map example

### DIFF
--- a/doc/completion-nvim.txt
+++ b/doc/completion-nvim.txt
@@ -71,8 +71,8 @@ g:completion_enable_auto_popup               *g:completion_enable_auto_popup*
         Or you want to use <tab> to trigger completion without modifying the
         usage to <tab> keys.
 >
-	nmap <tab> <Plug>(completion_smart_tab)
-	nmap <s-tab> <Plug>(completion_smart_s_tab)
+	imap <tab> <Plug>(completion_smart_tab)
+	imap <s-tab> <Plug>(completion_smart_s_tab)
 <
 
         default value: 1


### PR DESCRIPTION
A minor typo fix in the documentation:

I believe that `completion_smart_tab` is intended to be used in insert mode.