### PR TITLE
bugfix: if lsp label defined, priority may return nil when get it fro…

### DIFF
--- a/lua/completion/source/lsp.lua
+++ b/lua/completion/source/lsp.lua
@@ -116,7 +116,7 @@ local function text_document_completion_list_to_complete_items(result, params)
       end
     end
     get_context_aware_snippets(item, completion_item, params.line_to_cursor)
-    item.priority = opt.get_option('items_priority')[item.kind]
+    item.priority = opt.get_option('items_priority')[item.kind] or opt.get_option('items_priority')[kind]
     item.menu = completion_item.detail or ''
     match.matching(matches, params.prefix, item)
   end


### PR DESCRIPTION
If both
```
 let g:completion_customize_lsp_label = {
     \ 'Function': "\uf794"
}
```
and 
```
let g:completion_items_priority = {
    \ 'Function': 8,
}
```
existed, priority for Function will be nil.

Error report is here: https://github.com/nvim-lua/completion-nvim/issues/256
