### PR TITLE
docs: use imap for smart tab completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ imap <silent> <c-p> <Plug>(completion_trigger)
 - Or you want to use `<Tab>` as trigger keys
 
 ```vim
-nmap <tab> <Plug>(completion_smart_tab)
-nmap <s-tab> <Plug>(completion_smart_s_tab)
+imap <tab> <Plug>(completion_smart_tab)
+imap <s-tab> <Plug>(completion_smart_s_tab)
 ```
 
 ### Enable Snippets Support


### PR DESCRIPTION
Changes the README docs for `<Plug>(completion_smart_tab)` and `<Plug>(completion_smart_s_tab)` to use `imap` instead of `nmap`.