### PR TITLE
Show signature help when hover is not supported

### DIFF
--- a/lua/completion/signature_help.lua
+++ b/lua/completion/signature_help.lua
@@ -20,9 +20,8 @@ M.autoOpenSignatureHelp = function()
       return
     end
 
-    if value.resolved_capabilities.hover == false then return end
-      triggered = util.checkTriggerCharacter(line_to_cursor,
-        value.server_capabilities.signatureHelpProvider.triggerCharacters)
+    triggered = util.checkTriggerCharacter(line_to_cursor,
+      value.server_capabilities.signatureHelpProvider.triggerCharacters)
   end
 
   if triggered then


### PR DESCRIPTION
I am running a Language Server that does not currently support hover.  This change removes the requirement that hover must be supported for signature help to be displayed automatically.