### PR TITLE
use completion_trigger_character option when set else fallback to lsp

### DIFF
--- a/lua/completion/option.lua
+++ b/lua/completion/option.lua
@@ -5,7 +5,7 @@ local M = {}
 local completion_opt_metatable = {
   __index = function(_, key)
     key = 'completion_'..key
-    return vim.g[key]
+    return vim.b[key] or vim.g[key]
   end
 }
 

--- a/lua/completion/source.lua
+++ b/lua/completion/source.lua
@@ -76,11 +76,13 @@ local triggerCurrentCompletion = function(bufnr, line_to_cursor, prefix, textMat
 
   -- handle source trigger character and user defined trigger character
   local source_trigger_character = getTriggerCharacter(complete_source)
-  local triggered
+  local trigger_char_option = opt.get_option('trigger_character')
+  local triggered 
   triggered = util.checkTriggerCharacter(line_to_cursor, source_trigger_character) or
-              util.checkTriggerCharacter(line_to_cursor, opt.get_option('trigger_character'))
+              util.checkTriggerCharacter(line_to_cursor, trigger_char_option)
 
-  if complete_source.complete_items ~= nil then
+  local use_lsp_trigger = table.getn(trigger_char_option) == 0
+  if use_lsp_trigger and complete_source.complete_items ~= nil then
     for _, source in ipairs(complete_source.complete_items) do
       if source == 'lsp' and vim.lsp.buf_get_clients() ~= nil then
         for _, value in pairs(vim.lsp.buf_get_clients()) do


### PR DESCRIPTION
When I was using clangd LSP, I encountered a situation that was sort of annoying to me. Its completionProvider has triggerCharacters = { ".", ">", ":" }. So when I type private: or public: in class, it triggered completion popup. In this situation, I kinda like to set my own g:completion_trigger_character = ['.', '::', '->'].
I don't know if anyone else is facing the same problem.