### PR TITLE
Document automatic parentheses insertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ supported.
 - Asynchronous completion using the `libuv` api.
 - Automatically open hover windows when popupmenu is available.
 - Automatically open signature help if it's available.
+- Automatically insert parentheses
 - Snippets integration with UltiSnips and Neosnippet and vim-vsnip.
 - Apply *additionalTextEdits* in LSP spec if it's available.
 - Chain completion support inspired by [vim-mucomplete](https://github.com/lifepillar/vim-mucomplete)
@@ -112,6 +113,14 @@ imap <silent> <c-p> <Plug>(completion_trigger)
 ```vim
 imap <tab> <Plug>(completion_smart_tab)
 imap <s-tab> <Plug>(completion_smart_s_tab)
+```
+
+### Enable automatic parentheses insertion
+
+- By default this setting is turned off. Turn it on by
+
+``` vim
+let g:completion_enable_auto_paren = 1
 ```
 
 ### Enable Snippets Support


### PR DESCRIPTION
The README gif shows a couple of features that are undocumented:
1. Automatic paren completion
2. Automatic parameter expansion and positioning the cursor on each argument.

I haven't looked in to 2.), assuming you're relying on one of the snippet providers.
This PR documents the first one.


![](https://user-images.githubusercontent.com/35623968/76489411-3ca1d480-6463-11ea-8c3a-7f0e3c521cdb.gif)