### PR TITLE
add: kind mapping for completion symbols LSP

### DIFF
--- a/lua/completion/util.lua
+++ b/lua/completion/util.lua
@@ -37,6 +37,8 @@ function M.addCompletionItems(item_table, item)
   if item.word == nil then return end
   local abbr_length = opt.get_option('abbr_length')
   local menu_length = opt.get_option('menu_length')
+  local symbol_kind_list = opt.get_option('symbol_kind_list')
+  local kind_symbol = symbol_kind_list[string.lower(item.kind)]
   if menu_length ~= 0 then
     if item.menu ~= nil and string.len(item.menu) > menu_length then
       item.menu = string.sub(item.menu, 0, menu_length).."..."
@@ -50,7 +52,7 @@ function M.addCompletionItems(item_table, item)
   table.insert(item_table, {
       word = item.word,
       abbr = item.abbr or '',
-      kind = item.kind or '',
+      kind = kind_symbol or '',
       menu = item.menu or '',
       info = item.info or '',
       priority = item.priority or 1,


### PR DESCRIPTION
Added custom symbol kind mapping for completion symbols in LSP.
This will allow users to override the default symbol kind mapping and
allow usage of custom symbols or text in the completion menu.

Achieved something like this

![image](https://user-images.githubusercontent.com/18033231/101970510-db589d00-3c50-11eb-983f-4d200d3b9424.png)

```vimscript
let g:completion_symbol_kind_list = {
            \    'function': '',
            \    'method': '',
            \    'variable': '',
            \    'constant': '',
            \    'struct': 'פּ',
            \    'class': '',
            \    'interface': '禍',
            \    'text': '',
            \    'enum': '',
            \    'enumMember': '',
            \    'module': '',
            \    'color': '',
            \    'property': '襁',
            \    'field': '綠',
            \    'unit': '',
            \    'file': '',
            \    'value': '',
            \    'event': '鬒',
            \    'folder': '',
            \    'keyword': '',
            \    'snippet': '',
            \    'operator': '洛',
            \    'reference': '',
            \    'typeParameter': '',
            \    'default': ''
            \  }
```

Fixes: #298