### PR TITLE
option to disable server trigger characters

### DIFF
--- a/doc/completion-nvim.txt
+++ b/doc/completion-nvim.txt
@@ -156,6 +156,14 @@ g:completion_trigger_character                *g:completion_trigger_character*
 
         default value: ['.']
 
+g:completion_enable_server_trigger        *g:completion_enable_server_trigger*
+
+	Wether or not to use the trigger characters provided by language 
+	server for triggering the popup menu.
+	You can turn it off by setting this option to zero.
+
+        default value: 1
+
 g:completion_trigger_keyword_length		    *g:completion_trigger_keyword_length*
 
 	You can specify keyword length for triggering completion, if the

--- a/lua/completion/source.lua
+++ b/lua/completion/source.lua
@@ -87,8 +87,10 @@ local triggerCurrentCompletion = function(bufnr, line_to_cursor, prefix, textMat
           if value.server_capabilities.completionProvider == nil then
             break
           end
-          triggered = triggered or util.checkTriggerCharacter(line_to_cursor,
-            value.server_capabilities.completionProvider.triggerCharacters)
+          if opt.get_option('enable_server_trigger') == 1 then
+            triggered = triggered or util.checkTriggerCharacter(line_to_cursor,
+              value.server_capabilities.completionProvider.triggerCharacters)
+          end
         end
         break
       end

--- a/plugin/completion.vim
+++ b/plugin/completion.vim
@@ -49,6 +49,10 @@ if ! exists('g:completion_trigger_character')
     let g:completion_trigger_character = []
 endif
 
+if ! exists('g:completion_enable_server_trigger')
+    let g:completion_enable_server_trigger = 1
+endif
+
 if ! exists('g:completion_enable_auto_popup')
     let g:completion_enable_auto_popup = 1
 endif


### PR DESCRIPTION
Adds option to ignore  the triggerCharacters  provided by the language server.
This helps when servers like sumneko provide undesirable trigger characters such as space,
which makes  g:completion_trigger_keyword_length be ignored.