### PR TITLE
Fix #313 (substring_match for Lisp): use simple=true

### DIFF
--- a/lua/completion/matching.lua
+++ b/lua/completion/matching.lua
@@ -30,7 +30,7 @@ end
 
 local function substring_match(prefix, word)
   prefix, word = setup_case(prefix, word)
-  if string.find(word, prefix) then
+  if string.find(word, prefix, 1, true) then
     return true
   else
     return false


### PR DESCRIPTION
We can't feed arbitrary prefixes to substring_match match in
non-simple mode. We run into problems when the buffer has alternative
word rules (Like Lisp buffers with vlime).

The simple parameter of `find` will perform a substring search instead of a regex matching.
```
The pattern argument also allows more complex searches. See the PatternsTutorial for more information. We can turn off the pattern matching feature by using the optional fourth argument plain. plain takes a boolean value and must be preceeded by index. E.g.,

    > = string.find("Hello Lua user", "%su")          -- find a space character followed by "u"
    10      11
    > = string.find("Hello Lua user", "%su", 1, true) -- turn on plain searches, now not found
    nil
```

The problem arises when prefix ends with % like for instance `foo%`.

When using normal Vim word boundaries, `%` will end a word, so it can't be part of a prefix.