### PR TITLE
resolved_capabilities -> resolved_server_capabilities

### DIFF
--- a/lua/completion/hover.lua
+++ b/lua/completion/hover.lua
@@ -358,7 +358,7 @@ M.autoOpenHoverInPopup = function()
       else
         local has_hover = false
         for _, value in pairs(vim.lsp.buf_get_clients(0)) do
-          if value.resolved_capabilities.hover then
+          if value.resolved_server_capabilities.hover then
             has_hover = true
             break
           end

--- a/lua/completion/signature_help.lua
+++ b/lua/completion/signature_help.lua
@@ -15,12 +15,12 @@ M.autoOpenSignatureHelp = function()
 
   local triggered
   for _, value in pairs(vim.lsp.buf_get_clients(0)) do
-    if value.resolved_capabilities.signature_help == false or
+    if value.resolved_server_capabilities.signature_help == false or
       value.server_capabilities.signatureHelpProvider == nil then
       return
     end
 
-    if value.resolved_capabilities.hover == false then return end
+    if value.resolved_server_capabilities.hover == false then return end
       triggered = util.checkTriggerCharacter(line_to_cursor,
         value.server_capabilities.signatureHelpProvider.triggerCharacters)
   end


### PR DESCRIPTION
As part of implementing dynamicRegistration requests https://github.com/neovim/neovim/pull/13642 I'm renaming resolved_capabilities to resolved_server_capabilities. If this is merged as it is currently, it will break completion-nvim. 

This PR should fix things. I can comment again once the PR is merged in neovim core. Sorry for the inconvenience!