### PR TITLE
feat: add completion result auto select

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,16 @@ imap <expr> <cr>  pumvisible() ? complete_info()["selected"] != "-1" ?
 let g:completion_enable_auto_hover = 0
 ```
 
+### Enable/Disable auto select
+
+- By default to confirm completion an result item must be selected manually.
+  You can enable automatic confirmation with [confirm key](#changing-completion-confirm-key)
+  without having to enter completion menu by
+
+```vim
+let g:completion_auto_select = 1
+```
+
 ### Enable/Disable auto signature
 
 - By default signature help opens automatically whenever it's available. Disable

--- a/autoload/completion.vim
+++ b/autoload/completion.vim
@@ -5,12 +5,21 @@ function! completion#completion_confirm() abort
 endfunction
 
 function! completion#wrap_completion() abort
-    if pumvisible() != 0 && complete_info()["selected"] != "-1"
-        call completion#completion_confirm()
-    else
-        call nvim_feedkeys("\<c-g>\<c-g>", "n", v:true)
-        let key = g:completion_confirm_key
-        call nvim_feedkeys(key, "n", v:true)
+    if g:completion_auto_select == 0
+        if pumvisible() != 0 && complete_info()["selected"] != "-1"
+            call completion#completion_confirm()
+        else
+            call nvim_feedkeys("\<c-g>\<c-g>", "n", v:true)
+            let key = g:completion_confirm_key
+            call nvim_feedkeys(key, "n", v:true)
+        endif
+    elseif g:completion_auto_select == 1
+        if pumvisible() != 0 && complete_info()["selected"] != "-1"
+            call completion#completion_confirm()
+        elseif pumvisible() != 0 && complete_info()["selected"] == "-1"
+            call nvim_feedkeys("\<C-n>", "n", v:true)
+            call completion#completion_confirm()
+        endif
     endif
 endfunction
 

--- a/lua/completion.lua
+++ b/lua/completion.lua
@@ -252,8 +252,7 @@ M.on_attach = function(option)
   api.nvim_command("augroup end")
   if string.len(opt.get_option('confirm_key')) ~= 0 then
     api.nvim_buf_set_keymap(0, 'i', opt.get_option('confirm_key'),
-      'pumvisible() ? complete_info()["selected"] != "-1" ? "\\<Plug>(completion_confirm_completion)" :'..
-      ' "\\<c-e>\\<CR>" : "\\<CR>"',
+      'pumvisible() ? "\\<Plug>(completion_confirm_completion)" : "\\<CR>"',
       {silent=false, noremap=false, expr=true})
   end
   vim.b.completion_enable = 1

--- a/plugin/completion.vim
+++ b/plugin/completion.vim
@@ -125,6 +125,10 @@ if ! exists('g:completion_menu_length')
     let g:completion_menu_length = 0
 endif
 
+if ! exists('g:completion_auto_select')
+    let g:completion_auto_select = 0
+endif
+
 inoremap <silent> <Plug>(completion_confirm_completion)
       \ <cmd>call completion#wrap_completion()<CR>
 


### PR DESCRIPTION
This is my first attempt to add auto selection and completion of topmost result item in completion menu without having to preselect it by just pressing confirmation key while completion menu is visible.

One thing I am not sure about is significance of `<C-e>` in https://github.com/nvim-lua/completion-nvim/blob/25dac52c4eb37bf28cc1b8fd6283b151db85e764/lua/completion.lua#L256 as it still seems to work as before with feature disabled `let g:completion_auto_select = 0`.

It probably needs more work, just wanted to get feedback.

It is based on what coc.nvim does, which I found very useful. 