### PR TITLE
feat: add customizability of dup option for lsp items

### DIFF
--- a/lua/completion/source/lsp.lua
+++ b/lua/completion/source/lsp.lua
@@ -93,6 +93,7 @@ local function text_document_completion_list_to_complete_items(result, params)
 
     item.word = get_completion_word(completion_item, params.prefix, params.suffix)
     item.word = item.word:gsub('\n', ' ')
+    item.dup = opt.get_option("lsp_dup")
     item.user_data = {
       lsp = {
         completion_item = completion_item,

--- a/lua/completion/source/lsp.lua
+++ b/lua/completion/source/lsp.lua
@@ -93,7 +93,7 @@ local function text_document_completion_list_to_complete_items(result, params)
 
     item.word = get_completion_word(completion_item, params.prefix, params.suffix)
     item.word = item.word:gsub('\n', ' ')
-    item.dup = opt.get_option("lsp_dup")
+    item.dup = opt.get_option("items_duplicate")['lsp']
     item.user_data = {
       lsp = {
         completion_item = completion_item,

--- a/lua/completion/source/snippet.lua
+++ b/lua/completion/source/snippet.lua
@@ -14,7 +14,7 @@ M.getUltisnipItems = function(prefix)
   end
   local priority = vim.g.completion_items_priority['UltiSnips'] or 1
   local kind = 'UltiSnips'
-  local dup = opt.get_option('lsp_dup_items')[kind] or 1
+  local dup = opt.get_option('items_duplicate')[kind] or 1
   kind = opt.get_option('customize_lsp_label')[kind] or kind
   for key, val in pairs(snippetsList) do
     local item = {}
@@ -38,7 +38,7 @@ M.getNeosnippetItems = function(prefix)
   end
   local kind = 'Neosnippet'
   kind = opt.get_option('customize_lsp_label')[kind] or kind
-  local dup = opt.get_option('lsp_dup_items')[kind] or 1
+  local dup = opt.get_option('items_duplicate')[kind] or 1
   local priority = vim.g.completion_items_priority['Neosnippet']
   for key, val in pairs(snippetsList) do
     local description
@@ -65,7 +65,7 @@ M.getVsnipItems = function(prefix)
   local kind = 'vim-vsnip'
   kind = opt.get_option('customize_lsp_label')[kind] or kind
   local priority = vim.g.completion_items_priority['vim-vsnip']
-  local dup = opt.get_option('lsp_dup_items')[kind] or 1
+  local dup = opt.get_option('items_duplicate')[kind] or 1
   for _, source in pairs(snippetsList) do
     for _, snippet in pairs(source) do
       for _, word in pairs(snippet.prefix) do
@@ -96,7 +96,7 @@ M.getSnippetsNvimItems = function(prefix)
   end
   local priority = vim.g.completion_items_priority['snippets.nvim'] or 1
   local kind = 'snippets.nvim'
-  local dup = opt.get_option('lsp_dup_items')[kind] or 1
+  local dup = opt.get_option('items_duplicate')[kind] or 1
   kind = opt.get_option('customize_lsp_label')[kind] or kind
   for short, long in pairs(snippetsList) do
     -- TODO: We cannot put the parsed snippet itself in userdata, since it may

--- a/lua/completion/source/snippet.lua
+++ b/lua/completion/source/snippet.lua
@@ -14,12 +14,14 @@ M.getUltisnipItems = function(prefix)
   end
   local priority = vim.g.completion_items_priority['UltiSnips'] or 1
   local kind = 'UltiSnips'
+  local dup = opt.get_option('lsp_dup_items')[kind] or 1
   kind = opt.get_option('customize_lsp_label')[kind] or kind
   for key, val in pairs(snippetsList) do
     local item = {}
     item.word = key
     item.kind = kind
     item.priority = priority
+    item.dup = dup
     local user_data = {snippet_source = 'UltiSnips', hover = val}
     item.user_data = user_data
     match.matching(complete_items, prefix, item)
@@ -36,6 +38,7 @@ M.getNeosnippetItems = function(prefix)
   end
   local kind = 'Neosnippet'
   kind = opt.get_option('customize_lsp_label')[kind] or kind
+  local dup = opt.get_option('lsp_dup_items')[kind] or 1
   local priority = vim.g.completion_items_priority['Neosnippet']
   for key, val in pairs(snippetsList) do
     local description
@@ -45,6 +48,7 @@ M.getNeosnippetItems = function(prefix)
     item.word = key
     item.kind = kind
     item.priority = priority
+    item.dup = dup
     item.user_data = user_data
     match.matching(complete_items, prefix, item)
   end
@@ -61,6 +65,7 @@ M.getVsnipItems = function(prefix)
   local kind = 'vim-vsnip'
   kind = opt.get_option('customize_lsp_label')[kind] or kind
   local priority = vim.g.completion_items_priority['vim-vsnip']
+  local dup = opt.get_option('lsp_dup_items')[kind] or 1
   for _, source in pairs(snippetsList) do
     for _, snippet in pairs(source) do
       for _, word in pairs(snippet.prefix) do
@@ -69,6 +74,7 @@ M.getVsnipItems = function(prefix)
         item.word = word
         item.kind = kind
         item.menu = snippet.label
+        item.dup = dup
         item.priority = priority
         item.user_data = user_data
         match.matching(complete_items, prefix, item)
@@ -90,6 +96,7 @@ M.getSnippetsNvimItems = function(prefix)
   end
   local priority = vim.g.completion_items_priority['snippets.nvim'] or 1
   local kind = 'snippets.nvim'
+  local dup = opt.get_option('lsp_dup_items')[kind] or 1
   kind = opt.get_option('customize_lsp_label')[kind] or kind
   for short, long in pairs(snippetsList) do
     -- TODO: We cannot put the parsed snippet itself in userdata, since it may
@@ -99,6 +106,7 @@ M.getSnippetsNvimItems = function(prefix)
     local item = {}
     item.word = short
     item.kind = kind
+    item.dup = dup
     -- TODO: Turn actual snippet text into label/description?
     item.menu = short
     item.priority = priority

--- a/plugin/completion.vim
+++ b/plugin/completion.vim
@@ -125,6 +125,10 @@ if ! exists('g:completion_menu_length')
     let g:completion_menu_length = 0
 endif
 
+if ! exists('g:completion_dup_items')
+    let g:completion_lsp_dup_items = {}
+endif
+
 inoremap <silent> <Plug>(completion_confirm_completion)
       \ <cmd>call completion#wrap_completion()<CR>
 
@@ -149,3 +153,5 @@ let &cpo = s:save_cpo
 unlet s:save_cpo
 
 let g:loaded_completion = 1
+
+

--- a/plugin/completion.vim
+++ b/plugin/completion.vim
@@ -125,8 +125,8 @@ if ! exists('g:completion_menu_length')
     let g:completion_menu_length = 0
 endif
 
-if ! exists('g:completion_dup_items')
-    let g:completion_lsp_dup_items = {}
+if ! exists('g:completion_items_duplicate')
+    let g:completion_items_duplicate = {}
 endif
 
 inoremap <silent> <Plug>(completion_confirm_completion)


### PR DESCRIPTION
Allow customize completion_items `dup` option

setup in vim:
`g:completion_items_duplicate = {‘lsp’: 0, ‘UltiSnips’: 0}`