### PR TITLE
Support vsnip's same prefix items

### DIFF
--- a/lua/completion.lua
+++ b/lua/completion.lua
@@ -137,7 +137,12 @@ local function hasConfirmedCompletion()
   elseif completed_item.user_data.snippet_source == 'Neosnippet' then
     api.nvim_input("<c-r>".."=neosnippet#expand('"..completed_item.word.."')".."<CR>")
   elseif completed_item.user_data.snippet_source == 'vim-vsnip' then
-    api.nvim_call_function('vsnip#expand', {})
+    api.nvim_call_function('vsnip#anonymous', {
+      table.concat(completed_item.user_data.snippet_body, "\n"),
+      {
+        prefix = completed_item.word
+      }
+    })
   elseif completed_item.user_data.snippet_source == 'snippets.nvim' then
     require'snippets'.expand_at_cursor()
   end

--- a/lua/completion/source/snippet.lua
+++ b/lua/completion/source/snippet.lua
@@ -69,7 +69,7 @@ M.getVsnipItems = function(prefix)
   for _, source in pairs(snippetsList) do
     for _, snippet in pairs(source) do
       for _, word in pairs(snippet.prefix) do
-        local user_data = {snippet_source = 'vim-vsnip', hover = snippet.description}
+        local user_data = {snippet_source = 'vim-vsnip', snippet_body = snippet.body, hover = snippet.description}
         local item = {}
         item.word = word
         item.kind = kind


### PR DESCRIPTION
Related https://github.com/hrsh7th/vim-vsnip/issues/160

Currently, completion-nvim expands snippet with `vsnip#expand`. This will re-detect snippet with `prefix`.

But if multiple items have the same prefix, it could be wrong behavior.

So I provide `snippet_body` as user_data and snippet expansion with `vsnip#anonymous`.