### PR TITLE
fix: InsertTextFormat should fallback to PlainText

### DIFF
--- a/lua/completion/source/lsp.lua
+++ b/lua/completion/source/lsp.lua
@@ -30,15 +30,17 @@ local function get_completion_word(item, prefix, suffix)
       else
           newText = item.textEdit.newText
       end
-    if protocol.InsertTextFormat[item.insertTextFormat] == "PlainText"
-		or opt.get_option('enable_snippet') == "snippets.nvim" then
+    if not item.insertTextFormat
+    or protocol.InsertTextFormat[item.insertTextFormat] == "PlainText"
+    or opt.get_option('enable_snippet') == "snippets.nvim" then
       return newText
     else
       return vim.lsp.util.parse_snippet(newText)
     end
   elseif item.insertText ~= nil and item.insertText ~= vim.NIL then
-    if protocol.InsertTextFormat[item.insertTextFormat] == "PlainText"
-		or opt.get_option('enable_snippet') == "snippets.nvim" then
+    if not item.insertTextFormat
+    or protocol.InsertTextFormat[item.insertTextFormat] == "PlainText"
+    or opt.get_option('enable_snippet') == "snippets.nvim" then
       return item.insertText
     else
       return vim.lsp.util.parse_snippet(item.insertText)


### PR DESCRIPTION
Fixes #252 
Currently intelephense gives `InsertTextFormat` of nil when completion item is requested on `$`.
According to LSP spec, It should be default to `PlainText` when `InsertTextFormat` is ommited.
>	/**
	 * The format of the insert text. The format applies to both the
	 * `insertText` property and the `newText` property of a provided
	 * `textEdit`. If omitted defaults to `InsertTextFormat.PlainText`.
	 */
	insertTextFormat?: InsertTextFormat;

https://raw.githubusercontent.com/microsoft/language-server-protocol/gh-pages/_specifications/specification-3-16.md

This pull request makes assumption that `InsertTextFormat` should be `PlainText` when ommited and returns `newText` or `insertText` correctly. 