### PR TITLE
signature_help: merge changes from neovim

### DIFF
--- a/lua/completion.lua
+++ b/lua/completion.lua
@@ -234,7 +234,7 @@ function M.on_CompleteDone()
     manager.confirmedCompletion = false
     hasConfirmedCompletion()
     -- auto trigger signature help when we confirm completion
-    if vim.g.completion_enable_auto_signature ~= 0 then
+    if opt.get_option('enable_auto_signature') == 1 then
       signature.autoOpenSignatureHelp()
     end
   end


### PR DESCRIPTION
This PR updates the `autoOpenSignatureHelp` function to behave as the builtin `signatureHelp` handler does (without printing an error message if there's no signature help available).

Note: we will have to merge changes manually if they change in upstream. Ideally, neovim's `textDocument/signatureHelp` would have a `config.silent` parameter so we could just use `vim.lsp.with([...], { silent = true })` as our handler.