### PR TITLE
Fix focusable_preview deprecation warnings

### DIFF
--- a/lua/completion/signature_help.lua
+++ b/lua/completion/signature_help.lua
@@ -42,11 +42,12 @@ M.autoOpenSignatureHelp = function()
       if vim.tbl_isempty(lines) then
         return
       end
-      local bufnr, _ = vim.lsp.util.focusable_preview(method, function()
+      local bufnr, _ = vim.lsp.util.open_floating_preview(
         -- TODO show popup when signatures is empty?
-        lines = vim.lsp.util.trim_empty_lines(lines)
-        return lines, vim.lsp.util.try_trim_markdown_code_blocks(lines)
-      end)
+        vim.lsp.util.trim_empty_lines(lines),
+        vim.lsp.util.try_trim_markdown_code_blocks(lines),
+        {focus_id = method}
+      )
       -- setup a variable for floating window, fix #223
       vim.api.nvim_buf_set_var(bufnr, "lsp_floating", true)
     end)


### PR DESCRIPTION
Changed the function call from the now deprecated `focusable_preview` to the new `open_floating_preview`

Since this neovim's commit (https://github.com/neovim/neovim/commit/64da499ac25bd833c57e0850e31affd22294049e), [focusable_preview](https://github.com/neovim/neovim/blob/64da499ac25bd833c57e0850e31affd22294049e/runtime/lua/vim/lsp/util.lua#L1034) is now deprecated in favour of the new [open_floating_preview](https://github.com/neovim/neovim/blob/64da499ac25bd833c57e0850e31affd22294049e/runtime/lua/vim/lsp/util.lua#L1321).