### PR TITLE
fix: signature help trimming breaks preview syntax

### DIFF
--- a/lua/completion/signature_help.lua
+++ b/lua/completion/signature_help.lua
@@ -42,10 +42,13 @@ M.autoOpenSignatureHelp = function()
       if vim.tbl_isempty(lines) then
         return
       end
+
+      -- if `lines` can be trimmed, it is modified in place
+      local trimmed_lines_filetype = vim.lsp.util.try_trim_markdown_code_blocks(lines)
       local bufnr, _ = vim.lsp.util.open_floating_preview(
         -- TODO show popup when signatures is empty?
         vim.lsp.util.trim_empty_lines(lines),
-        vim.lsp.util.try_trim_markdown_code_blocks(lines),
+        trimmed_lines_filetype,
         {}
       )
       -- setup a variable for floating window, fix #223


### PR DESCRIPTION
As `vim.lsp.util.try_trim_markdown_code_blocks` modifies its input in place, it has to be evaluated before the input is used elsewhere. Prior to this change, if trimming could be performed, the floating window would be given the untrimmed markdown to render, but was given e.g. `rust` as the window filetype.

Example:

![2021-07-03-150814_735x255_scrot](https://user-images.githubusercontent.com/9393486/124356941-e7b63e80-dc10-11eb-988d-2e87e21e3f0d.png)

Fixed:

![2021-07-03-150939_735x255_scrot](https://user-images.githubusercontent.com/9393486/124356942-e9800200-dc10-11eb-9c5a-2b39d0cbdcd0.png)