### PR TITLE
Add border to floating windows

### DIFF
--- a/doc/completion-nvim.txt
+++ b/doc/completion-nvim.txt
@@ -123,6 +123,16 @@ g:completion_enable_auto_signature        *g:completion_enable_auto_signature*
 
         default value: 1
 
+g:completion_popup_border        		*g:completion_popup_border*
+
+	By default border for auto hover popup and signature help popup
+	are set to single. You can change it as per neovim's popup/preview
+	window sepcifications.
+
+	available options: 'single', 'double', 'rounded', 'solid' and 'shadow'
+
+        default value: 'single'
+
 g:completion_enable_auto_paren		      *g:completion_enable_auto_paren*
 
 	Enable the auto insert parenthesis feature. completion-nvim will

--- a/doc/completion-nvim.txt
+++ b/doc/completion-nvim.txt
@@ -125,13 +125,14 @@ g:completion_enable_auto_signature        *g:completion_enable_auto_signature*
 
 g:completion_popup_border        		*g:completion_popup_border*
 
-	By default border for auto hover popup and signature help popup
-	are set to single. You can change it as per neovim's popup/preview
+	This variable sets border for auto hover popup and signature help popup.
+	The variable is not created by default so that there is no border by
+	default. You can set it as per neovim's popup/preview
 	window sepcifications.
 
 	available options: 'single', 'double', 'rounded', 'solid' and 'shadow'
 
-        default value: 'single'
+        default value: variable not declared
 
 g:completion_enable_auto_paren		      *g:completion_enable_auto_paren*
 

--- a/lua/completion/hover.lua
+++ b/lua/completion/hover.lua
@@ -73,6 +73,17 @@ local make_floating_popup_options = function(width, height, opts)
     col = opts.col - width - 1
   end
 
+  local default_border = {
+    {"", "NormalFloat"},
+    {"", "NormalFloat"},
+    {"", "NormalFloat"},
+    {" ", "NormalFloat"},
+    {"", "NormalFloat"},
+    {"", "NormalFloat"},
+    {"", "NormalFloat"},
+    {" ", "NormalFloat"},
+  }
+
   return {
     col = col,
     height = height,
@@ -81,7 +92,7 @@ local make_floating_popup_options = function(width, height, opts)
     focusable = false,
     style = 'minimal',
     width = width,
-	border = vim.g.completion_popup_border
+	border = vim.g.completion_popup_border or default_border
   }
 end
 

--- a/lua/completion/hover.lua
+++ b/lua/completion/hover.lua
@@ -81,6 +81,7 @@ local make_floating_popup_options = function(width, height, opts)
     focusable = false,
     style = 'minimal',
     width = width,
+	border = vim.g.completion_popup_border
   }
 end
 

--- a/lua/completion/hover.lua
+++ b/lua/completion/hover.lua
@@ -92,7 +92,7 @@ local make_floating_popup_options = function(width, height, opts)
     focusable = false,
     style = 'minimal',
     width = width,
-	border = vim.g.completion_popup_border or default_border
+    border = vim.g.completion_popup_border or default_border
   }
 end
 

--- a/lua/completion/signature_help.lua
+++ b/lua/completion/signature_help.lua
@@ -48,13 +48,13 @@ M.autoOpenSignatureHelp = function()
       local trimmed_lines_filetype = vim.lsp.util.try_trim_markdown_code_blocks(lines)
 	  local opts = {}
 	  if vim.g.completion_popup_border then
-		opts.border = vim.g.completion_popup_border
+	    opts.border = vim.g.completion_popup_border
 	  end
       local bufnr, _ = vim.lsp.util.open_floating_preview(
         -- TODO show popup when signatures is empty?
         vim.lsp.util.trim_empty_lines(lines),
         trimmed_lines_filetype,
-		opts
+	opts
       )
       -- setup a variable for floating window, fix #223
       vim.api.nvim_buf_set_var(bufnr, "lsp_floating", true)

--- a/lua/completion/signature_help.lua
+++ b/lua/completion/signature_help.lua
@@ -46,7 +46,10 @@ M.autoOpenSignatureHelp = function()
 
       -- if `lines` can be trimmed, it is modified in place
       local trimmed_lines_filetype = vim.lsp.util.try_trim_markdown_code_blocks(lines)
-	  local opts = {border = vim.g.completion_popup_border}
+	  local opts = {}
+	  if vim.g.completion_popup_border then
+		opts.border = vim.g.completion_popup_border
+	  end
       local bufnr, _ = vim.lsp.util.open_floating_preview(
         -- TODO show popup when signatures is empty?
         vim.lsp.util.trim_empty_lines(lines),

--- a/lua/completion/signature_help.lua
+++ b/lua/completion/signature_help.lua
@@ -46,11 +46,12 @@ M.autoOpenSignatureHelp = function()
 
       -- if `lines` can be trimmed, it is modified in place
       local trimmed_lines_filetype = vim.lsp.util.try_trim_markdown_code_blocks(lines)
+	  local opts = {border = vim.g.completion_popup_border}
       local bufnr, _ = vim.lsp.util.open_floating_preview(
         -- TODO show popup when signatures is empty?
         vim.lsp.util.trim_empty_lines(lines),
         trimmed_lines_filetype,
-        {}
+		opts
       )
       -- setup a variable for floating window, fix #223
       vim.api.nvim_buf_set_var(bufnr, "lsp_floating", true)

--- a/plugin/completion.vim
+++ b/plugin/completion.vim
@@ -25,6 +25,10 @@ if ! exists('g:completion_enable_auto_hover')
     let g:completion_enable_auto_hover = 1
 endif
 
+if ! exists('g:completion_popup_border')
+    let g:completion_popup_border = 'single'
+endif
+
 if ! exists('g:completion_docked_hover')
     let g:completion_docked_hover = 0
 endif

--- a/plugin/completion.vim
+++ b/plugin/completion.vim
@@ -25,10 +25,6 @@ if ! exists('g:completion_enable_auto_hover')
     let g:completion_enable_auto_hover = 1
 endif
 
-if ! exists('g:completion_popup_border')
-    let g:completion_popup_border = 'single'
-endif
-
 if ! exists('g:completion_docked_hover')
     let g:completion_docked_hover = 0
 endif


### PR DESCRIPTION
Leverage neovim's new Api for floating windows with borders. This applies to auto_hover and signature_help